### PR TITLE
Upgrade google-auth-library dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "babel-polyfill": "~6.16.0",
     "debug": "^2.2.0",
     "extend": "^3.0.0",
-    "google-auth-library": "^0.9.8",
+    "google-auth-library": "^1.6.1",
     "googleapis": "~16.1",
     "highlight.js": "^9.7.0",
     "inline-styles-parse": "^1.2.0",
@@ -68,9 +68,9 @@
     "chai-as-promised": "^5.3.0",
     "chai-subset": "^1.3.0",
     "eslint": "^3.6.0",
-    "mocha": "^3.0.2",
+    "mocha": "^5.2.0",
     "mock-fs": "^4.5.0",
-    "nock": "^8.0.0"
+    "nock": "^9.6.1"
   },
   "bin": {
     "md2gslides": "bin/md2gslides.js"

--- a/src/auth.js
+++ b/src/auth.js
@@ -17,7 +17,7 @@
 const assert = require('assert');
 const debug = require('debug')('md2gslides');
 const Promise = require('promise');
-const GoogleAuth = require('google-auth-library');
+const {OAuth2Client} = require('google-auth-library');
 const path = require('path');
 const mkdirp = require('mkdirp');
 const lowdb = require('lowdb');
@@ -76,8 +76,7 @@ class UserAuthorizer {
      * @returns {Promise.<google.auth.OAuth2>}
      */
     getUserCredentials(user, scopes) {
-        const auth = new GoogleAuth();
-        const oauth2Client = new auth.OAuth2(this.clientId, this.clientSecret, this.redirectUrl);
+        const oauth2Client = new OAuth2Client(this.clientId, this.clientSecret, this.redirectUrl);
         let previousToken = this.db.get(user).value();
         let saveToken = () => this.db.set(user, oauth2Client.credentials).value();
         let emitCredentials = () => oauth2Client;


### PR DESCRIPTION
Just trying to update some packages since npm warned me of vulnerabilities.

I upgraded the `google-auth-library` version and tested it by running the usual tests and creating a presentation. It seems to work for the most part except for the auth.spec.js which is failing because nock does not work well with intercepting axios requests See for instance [here](https://github.com/axios/axios/issues/305)

I am not too sure of what would be the best path forward here, either migrating to moxios, or finding a way to correctly intercept from nock by apparently [using a shim for the http adapter](https://github.com/axios/axios/issues/305#issuecomment-222747336), but I was not able to make this work.

I am just putting this here in case someone encounters a similar issue, but feel free to close if it is not helpful.

