### PR TITLE
bring your own credentials (issue #64)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,14 @@ npm install -g md2gslides
 ```
 
 Then get your OAuth client ID credentials:
-- Create (or reuse) a developer project at <https://console.developers.google.com>
-- Enable Google Slides API at [API library page](https://console.developers.google.com/apis/library)
-- Go to [Credentials page](https://console.developers.google.com/apis/credentials) and click "+ Create credentials" at the top
-- Select "OAuth client ID" authorization credentials, choose "Other", and give it a name (or take the default)
-- Download client credentials file... you'll be prompted with a long name like, `client\_secret\__LARGE-HASH_.json`, but simplify to `client_id.json` and save to `~/.md2googleslides`.
+
+* Create (or reuse) a developer project at <https://console.developers.google.com>
+* Enable Google Slides API at [API library page](https://console.developers.google.com/apis/library)
+* Go to [Credentials page](https://console.developers.google.com/apis/credentials) and click "+ Create credentials" at the top
+* Select "OAuth client ID" authorization credentials
+* Choose type "Computer Application" and give it some name.
+* Download client credentials file.
+* Copy it to `client_id.json` (name has to match) and save to `~/.md2googleslides`.
 
 After installing, import your slides by running:
 

--- a/README.md
+++ b/README.md
@@ -19,14 +19,21 @@ For command line use, install md2gslides globally:
 npm install -g md2gslides
 ```
 
+Then get your OAuth client ID credentials:
+- Create (or reuse) a developer project at <https://console.developers.google.com>
+- Enable Google Slides API at [API library page](https://console.developers.google.com/apis/library)
+- Go to [Credentials page](https://console.developers.google.com/apis/credentials) and click "+ Create credentials" at the top
+- Select "OAuth client ID" authorization credentials, choose "Other", and give it a name (or take the default)
+- Download client credentials file... you'll be prompted with a long name like, `client\_secret\__LARGE-HASH_.json`, but simplify to `client_id.json` and save to `~/.md2googleslides`.
+
 After installing, import your slides by running:
 
 ```sh
 md2gslides slides.md
 ```
 
-The first time the command is run you will be prompted for authorization. Credentials
-will be stored locally in a file named `~/.credentials/md2gslides.json`.
+The first time the command is run you will be prompted for authorization. OAuth token
+credentials will be stored locally in a file named `~/.md2googleslides/credentials.json`.
 
 ## Supported markdown rules
 

--- a/bin/md2gslides.js
+++ b/bin/md2gslides.js
@@ -31,6 +31,7 @@ const SCOPES = ['https://www.googleapis.com/auth/presentations', 'https://www.go
 
 const USER_HOME = process.env.HOME || process.env.HOMEPATH || process.env.USERPROFILE;
 const STORED_CREDENTIALS_PATH = path.join(USER_HOME, '.md2googleslides', 'credentials.json');
+const STORED_CLIENT_ID_PATH = path.join(USER_HOME, '.md2googleslides', 'client_id.json');
 
 var parser = new ArgumentParser({
     version: '1.0.0',
@@ -124,9 +125,23 @@ function authorizeUser() {
     // application/utility such as this.  Of course, in such cases the "secret" is
     // actually publicly known; security depends entirely on the secrecy of refresh
     // tokens, which effectively become bearer tokens.
+
+    // Load and parse client ID and secret from client_id.json file. (Create
+    // OAuth client ID from Credentials tab at console.developers.google.com
+    // and download the credentials as client_id.json to ~/.md2googleslides
+    var data; // needs to be scoped outside of try-catch
+    try {
+        data = fs.readFileSync(STORED_CLIENT_ID_PATH);
+    } catch(err) {
+        return console.log('Error loading client secret file:', err);
+    }
+    if(data === undefined) return console.log('Error loading client secret data:', err);
+    const creds = JSON.parse(data).installed;
+
+    // Authorize user and get (& store) a valid access token.
     const options = {
-        clientId: '52512509792-pc54t7beete33ifbhk00q3cpcpkmfi7c.apps.googleusercontent.com',
-        clientSecret: '8g6up8tcVXgF7IO71mCN8Afk',
+        clientId: creds.client_id,
+        clientSecret: creds.client_secret,
         filePath: STORED_CREDENTIALS_PATH,
         prompt: prompt,
     };


### PR DESCRIPTION
One possible patch for </issues/64> where users are directed to the devconsole/API mgr and download their client ID & secret file as client_id.json. Store it in the same folder as their OAuth token files in ~/. md2googleslides.